### PR TITLE
Support for 'pulumi stack outputs' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This will check out the existing directory and run `pulumi preview`.
 The action can be configured with the following arguments:
 
 - `command` (required) - The command to run as part of the action. Accepted
-  values are `up` (update), `refresh`, `destroy` and `preview`.
+  values are `up` (update), `refresh`, `destroy`, `preview` and `outputs`.
 
 - `stack-name` (required) - The name of the stack that Pulumi will be operating
   on. Use the fully quaified org-name/stack-name when operating on a stack

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ export const command = rt.Union(
   rt.Literal('refresh'),
   rt.Literal('destroy'),
   rt.Literal('preview'),
+  rt.Literal('outputs'),
 );
 
 export type Commands = rt.Static<typeof command>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,6 +76,7 @@ const main = async () => {
       onOutput(stderr);
       return stdout;
     },
+    outputs: () => new Promise(() => '') //do nothing, outputs are fetched anyway afterwards
   };
 
   core.debug(`Running action ${config.command}`);


### PR DESCRIPTION
Adds support for an additional command that only prints output stack if available without performing any changes